### PR TITLE
feat: 增加底部备案信息及对应设置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -67,3 +67,15 @@ spec:
           label: 小部件
           value: "profile,popular-posts,latest-comments,categories,tags"
           help: "目前提供的小部件有：profile（站点资料）, popular-posts（热门文章）, latest-comments（最新评论）, categories（文章分类）, tags（文章标签）。你可以随意组合或排序，以逗号隔开。"
+    
+    - group: beian
+      label: 备案设置
+      formSchema:
+        - $formkit: text
+          name: icp_text
+          label: ICP备案号
+        - $formkit: text
+          name: icp_link
+          label: ICP备案跳转链接
+          value: https://beian.miit.gov.cn/
+        

--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -21,6 +21,9 @@
   </div>
   <hr class="my-6 border-gray-100 sm:mx-auto lg:my-8" />
   <span class="container mx-auto block text-center text-sm text-gray-500">
+    <a href="https://beian.miit.gov.cn/" class="hover:underline" target="_blank" th:href="${theme.config.beian.icp_link}" th:text="${theme.config.beian.icp_text}"></a>
+  </span>
+  <span class="container mx-auto block text-center text-sm text-gray-500">
     © 2022
     <a href="/" class="hover:underline" th:text="${site.title}"></a>. All Rights Reserved. Powered by
     <a href="https://halo.run" class="hover:underline" target="_blank">Halo</a>.


### PR DESCRIPTION
### 背景
在大陆上线的站点都需要在底部显示备案信息，目前这个主题没有相关显示信息及对应配置。

### 修改内容
在主题底部增加了 ICP 备案号显示，并增加了 `ICP备案号` 及 `ICP备案跳转链接` 两个配置。当不配置备案号时，底部显示内容与修改前相同。

### 效果图
#### 主题底部
![image](https://user-images.githubusercontent.com/27671436/197946180-5c74b2d7-10aa-4127-9420-87e5a330f461.png)
#### 主题设置
![image](https://user-images.githubusercontent.com/27671436/197946246-cfb21d5f-7a59-4fe8-9167-ec5b65797dbd.png)

```release-note
feat: 增加底部备案信息及对应设置
```
